### PR TITLE
unregister existed configuration when pod restarted with the same name

### DIFF
--- a/internal/imports/imports_linux.go
+++ b/internal/imports/imports_linux.go
@@ -23,6 +23,7 @@ import (
 	_ "k8s.io/api/admissionregistration/v1"
 	_ "k8s.io/api/apps/v1"
 	_ "k8s.io/api/core/v1"
+	_ "k8s.io/apimachinery/pkg/api/errors"
 	_ "k8s.io/apimachinery/pkg/api/resource"
 	_ "k8s.io/apimachinery/pkg/apis/meta/v1"
 	_ "k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
Signed-off-by: Nikolay Chunosov <n.chunosov@yandex.ru>

Issue https://github.com/networkservicemesh/deployments-k8s/issues/5000