### PR TITLE
qfix: add POD_NAME env for injected pods

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,6 +101,14 @@ func (c *Config) initializeEnvs() {
 				},
 			},
 		},
+		corev1.EnvVar{
+			Name: "POD_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
 	)
 }
 


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Motivation

To be able to support network services by podName
```
      routes:
        - destination_selector:
            podName: "{{ .podName }}"
```
we need to intject podName env