### PR TITLE
fix: don't panic if no labels in the target resource

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,6 +133,9 @@ func (s *admissionWebhookServer) unmarshal(in *admissionv1.AdmissionRequest) (p 
 		return "", nil, nil
 	}
 	p = path.Join("/", p)
+	if metaPtr.Labels == nil {
+		metaPtr.Labels = make(map[string]string)
+	}
 	return p, metaPtr, podSpec
 }
 


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>


Fixes nil pointer excpetion if resouces doesnt have labels

Usecase:

1. Deploy pod/deployment/daemonset/replicaset with nsm annotation without labels

Actual: npe
Execpted: we dont panic
